### PR TITLE
Adding TLF designer event

### DIFF
--- a/src/assets/events/README.md
+++ b/src/assets/events/README.md
@@ -3,7 +3,7 @@ COSA Events
 Edit events.json to include an event. Add a new array item with the following attributes:
 
 - **title** (required) - short name of the event
-- **type** (required) - event type. Possible values: webinar, conference, hackathon, other
+- **type** (required) - event type. Possible values: webinar, conference, hackathon, workshop, other
 - **description** (required) - name of a markup file with event description
 - **logo** (optional) - name of an image file or URL used as a logo for the event
 - **startDate** - event start date in format YYYY-MM-DD (2000-12-31). After that date event will become inactive if end date is not specified.

--- a/src/assets/events/events.json
+++ b/src/assets/events/events.json
@@ -1,5 +1,10 @@
 [
   {
+    "title": "TLF Designer",
+    "description": "tlfdesigner_workshop_2022.md",
+    "type": "workshop",
+    "startDate": "2022-09-13"
+  },{
     "title": "Dataset-JSON",
     "description": "hackathon_dataset_json.md",
     "type": "hackathon",

--- a/src/assets/events/tlfdesigner_workshop_2022.md
+++ b/src/assets/events/tlfdesigner_workshop_2022.md
@@ -1,0 +1,5 @@
+13 September 2022  11:00-14:00 US ET
+
+---
+
+Join CDISC for an interactive workshop to understand and define user needs and requirements for the [TFL Designer](https://cosa.cdisc.org/directory/tflDesigner). TFL Designer is a COSA-approved, open-source software project intended to create TFLs and generate associated metadata that supports clinical trial data analysis and reporting

--- a/src/components/Events/EventsTimeline.tsx
+++ b/src/components/Events/EventsTimeline.tsx
@@ -39,7 +39,7 @@ const EventsTimeline: React.FC<ITimelineProps> = ({
                 <ContactPhoneIcon sx={{ color: 'primary.main' }} />
               </TimelineDot>
             )}
-            {event.type === 'hackathon' && (
+            {['hackathon', 'workshop'].includes(event.type) && (
               <TimelineDot color='primary'>
                 <ConstructionIcon />
               </TimelineDot>


### PR DESCRIPTION
Adding the TLF designer event to the events section.
Added new type of event - workshop, as it looks we are now distinguishing hackathons and workshops.