### PR TITLE
Give contents: write permissions to gh pages action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,6 +12,8 @@ jobs:
     concurrency: ci-${{ github.ref }} # Recommended if you intend to make multiple deployments in quick succession.
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
+    permissions:
+      contents: write # This is required for JamesIves/github-pages-deploy-action
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v2


### PR DESCRIPTION
Fix to solve gh action error: https://github.com/cdisc-org/cosa/actions/runs/12347372314/job/34454368196

Issue was caused by our switch to enterprise as described here: https://github.com/orgs/community/discussions/57244

This action requires `contents: write` permissions as described here:
https://github.com/JamesIves/github-pages-deploy-action?tab=readme-ov-file#getting-started-airplane