### PR TITLE
Add HTP42 OSB USDM Uploader

### DIFF
--- a/ htp42-osb-usdm-uploader.yaml.rtf
+++ b/ htp42-osb-usdm-uploader.yaml.rtf
@@ -1,0 +1,60 @@
+{\rtf1\ansi\ansicpg1252\cocoartf2822
+\cocoatextscaling0\cocoaplatform0{\fonttbl\f0\fswiss\fcharset0 Helvetica;}
+{\colortbl;\red255\green255\blue255;}
+{\*\expandedcolortbl;;}
+\paperw11900\paperh16840\margl1440\margr1440\vieww11520\viewh8400\viewkind0
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural\partightenfactor0
+
+\f0\fs24 \cf0 name: HTP42 OSB USDM Uploader\
+\
+owner:\
+  name: HealthTechPartners42 (HTP42)\
+  type: organization\
+  contact:\
+    name: Phoebe\
+    email: phoebe@htp42.com\
+\
+description: >\
+  Open-source Python tool that ingests CDISC/TransCelerate USDM-compliant\
+  study definitions and materializes them inside OpenStudyBuilder (OSB),\
+  enabling automated, consistent, and standardized digital study setup\
+  aligned with CDISC Digital Data Flow (DDF).\
+\
+project_links:\
+  landing_page: https://github.com/HTP42-OpenStudyBuilder/OSB-usdm-uploader?tab=readme-ov-file#usdm-uploader\
+  repository: https://github.com/HTP42-OpenStudyBuilder/OSB-usdm-uploader\
+  documentation: https://github.com/HTP42-OpenStudyBuilder/OSB-usdm-uploader?tab=readme-ov-file\
+  demo:\
+    - https://www.youtube.com/watch?v=w3EffuJrzRs\
+    - https://www.youtube.com/watch?v=eJ4C1ZFtK-8\
+\
+license:\
+  name: MIT\
+  url: https://opensource.org/licenses/MIT\
+\
+programming_languages:\
+  - Python\
+\
+cdisc_standards:\
+  - USDM\
+  - Digital Data Flow (DDF)\
+\
+maturity: stable\
+\
+intended_users:\
+  - programmer\
+  - study designer\
+\
+capabilities:\
+  - Automates ingestion of USDM-formatted study definitions into OSB\
+  - Eliminates manual study creation via UI\
+  - Ensures alignment with CDISC and TransCelerate USDM standards\
+  - Supports downstream generation of study artifacts (SoA, CRFs, EDC)\
+\
+maintenance:\
+  issue_tracking: https://github.com/HTP42-OpenStudyBuilder/OSB-usdm-uploader/issues\
+  contribution_guidelines: https://github.com/HTP42-OpenStudyBuilder/OSB-usdm-uploader\
+\
+code_of_ethics:\
+  cdisc_compliant: true\
+}


### PR DESCRIPTION
This PR adds HTP42 OSB USDM Uploader to the CDISC COSA catalog.

The project is an open-source Python tool that ingests CDISC/TransCelerate
USDM-compliant study definitions and materializes them inside OpenStudyBuilder,
supporting CDISC Digital Data Flow (DDF) principles and automated study setup.

License: MIT
Primary standards: USDM, DDF
Repository: https://github.com/HTP42-OpenStudyBuilder/OSB-usdm-uploader