### PR TITLE
Sanitized untrusted URLs

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Single Page Apps for GitHub Pages</title>
     <script type="text/javascript">
       // Single Page Apps for GitHub Pages
@@ -28,7 +29,7 @@
       var l = window.location;
 
       // This is to support both, custom domain and github.io domain
-      if (l.href.includes('cosa.cdisc.org')){
+      if (l.hostname === 'cosa.cdisc.org'){
         pathSegmentsToKeep = 0;
       }
 


### PR DESCRIPTION
- Will only use DNS name cosa.cdisc.org
- Added `viewport `meta tag to the <head> section 
- Added the `lang` attribute to the <html> element

