### PR TITLE
Replaced line 28 with the pinned commit hash for v4

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,7 @@ jobs:
           npm run build
 
       - name: Deploy 🚀
-        uses: JamesIves/github-pages-deploy-action@v4
+        uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f # v4
         with:
           branch: gh-pages # The branch the action should deploy to.
           folder: build # The folder the action should deploy.


### PR DESCRIPTION
The SHA d92aa235d04922e8f08b40ce78cc5442fcfbfa2f corresponds to the v4 tag. The # v4 comment keeps it human-readable.


```json
{
  "ref": "refs/tags/v4",
  "node_id": "MDM6UmVmMTczNDY4ODE2OnJlZnMvdGFncy92NA==",
  "url": "https://api.github.com/repos/JamesIves/github-pages-deploy-action/git/refs/tags/v4",
  "object": {
    "sha": "d92aa235d04922e8f08b40ce78cc5442fcfbfa2f",
    "type": "commit",
    "url": "https://api.github.com/repos/JamesIves/github-pages-deploy-action/git/commits/d92aa235d04922e8f08b40ce78cc5442fcfbfa2f"
  }
}
```
